### PR TITLE
Fix faster than btc coins

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -69,7 +69,7 @@ const render = (coins, sortBy) => {
 				<td>${escapeHTML(`${coin.algorithm} @ ${formatHashrate(coin.hashrate)}`)}</td>
 				<td>${escapeHTML(coin.confirmations.toLocaleString())} confs</td>
 				<td>${escapeHTML(formatSeconds(coin.timeForConfs))}</td>
-				<td>${escapeHTML(coin.symbol === 'BTC' ? '-' : `${Math.round(coin.multiplier).toLocaleString()}x ${coin.isFaster ? 'faster' : 'slower'}`)}</td>
+				<td>${escapeHTML(coin.symbol === 'BTC' ? '-' : `${coin.formattedMultiplier}x ${coin.isFaster ? 'faster' : 'slower'}`)}</td>
 			</tr>
 			`).join('')}
 			</tbody>
@@ -92,6 +92,7 @@ fetch('https://howmanyconfs.com/api/data')
 				const confirmations = Math.ceil(workTime / coin.blockTimeInSeconds);
 				const timeForConfs = (coin.blockTimeInSeconds * confirmations);
 				const isFaster = multiplier < 1;
+				const formattedMultiplier = isFaster ? (1 / multiplier).toLocaleString(undefined, { maximumFractionDigits: 2 }) : Math.round(multiplier).toLocaleString()
 
 				return {
 					...coin,
@@ -99,7 +100,8 @@ fetch('https://howmanyconfs.com/api/data')
 					workTime,
 					confirmations,
 					timeForConfs,
-					isFaster
+					isFaster,
+					formattedMultiplier
 				};
 			});
 

--- a/js/index.js
+++ b/js/index.js
@@ -69,7 +69,7 @@ const render = (coins, sortBy) => {
 				<td>${escapeHTML(`${coin.algorithm} @ ${formatHashrate(coin.hashrate)}`)}</td>
 				<td>${escapeHTML(coin.confirmations.toLocaleString())} confs</td>
 				<td>${escapeHTML(formatSeconds(coin.timeForConfs))}</td>
-				<td>${escapeHTML(coin.symbol === 'BTC' ? '-' : `${Math.round(coin.multiplier).toLocaleString()}x slower`)}</td>
+				<td>${escapeHTML(coin.symbol === 'BTC' ? '-' : `${Math.round(coin.multiplier).toLocaleString()}x ${coin.isFaster ? 'faster' : 'slower'}`)}</td>
 			</tr>
 			`).join('')}
 			</tbody>
@@ -91,13 +91,15 @@ fetch('https://howmanyconfs.com/api/data')
 				const workTime = (bitcoin.blockTimeInSeconds * BITCOIN_CONFIRMATIONS * multiplier);
 				const confirmations = Math.ceil(workTime / coin.blockTimeInSeconds);
 				const timeForConfs = (coin.blockTimeInSeconds * confirmations);
+				const isFaster = multiplier < 1;
 
 				return {
 					...coin,
 					multiplier,
 					workTime,
 					confirmations,
-					timeForConfs
+					timeForConfs,
+					isFaster
 				};
 			});
 


### PR DESCRIPTION
The current master shows "faster than btc" coins as 1x slower, this PR adds the "faster" label and fixes the multiplier.

Before:
![image](https://user-images.githubusercontent.com/12701942/117631517-9b083700-b17c-11eb-942d-2cf2bbc8d314.png)

After:
![image](https://user-images.githubusercontent.com/12701942/117631560-a5c2cc00-b17c-11eb-9417-cf254b634fda.png)
